### PR TITLE
Updated to use setuptools if installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,11 @@ if 'sdist' in sys.argv:
         f.write(pypandoc.convert('README.md', 'rst', format='markdown'))
 
 import os
-from distutils.core import setup
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 #TODO: dependencies
 


### PR DESCRIPTION
In order to be able to do

`python setup.py develop`

I changed the setup to try to use setuptools if it is present.