### PR TITLE
Fix conf.py to mock GUI deps before importing torc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,12 +1,27 @@
 import sys
 import os
+from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath('..'))
 
-# Mock heavy GUI dependencies that aren't available on readthedocs:
-autodoc_mock_imports = ['pyqtgraph', 'PySide6', 'OpenGL']
+# Mock heavy GUI dependencies before importing torc, since torc.py imports them
+# at module level and they aren't available in the ReadTheDocs build environment.
+_gui_mocks = [
+    'pyqtgraph',
+    'pyqtgraph.opengl',
+    'pyqtgraph.Qt',
+    'pyqtgraph.Qt.QtCore',
+    'PySide6',
+    'OpenGL',
+    'OpenGL.GL',
+]
+for _mod in _gui_mocks:
+    sys.modules[_mod] = MagicMock()
 
 from torc import __version__
+
+# Also mock for autodoc when it processes source files:
+autodoc_mock_imports = ['pyqtgraph', 'PySide6', 'OpenGL']
 
 extensions = [
     'sphinx.ext.autodoc',


### PR DESCRIPTION
torc/torc.py imports pyqtgraph at module level, so the previous autodoc_mock_imports setting wasn't enough — those mocks only apply during autodoc processing, not when conf.py itself executes. Add sys.modules mocking before the torc import so the build works on ReadTheDocs.

https://claude.ai/code/session_01Lf19tSASkXRNL5Hiz1mncC